### PR TITLE
whitespace cleanup and adding service user counts

### DIFF
--- a/input_syno_telegraf.conf
+++ b/input_syno_telegraf.conf
@@ -85,7 +85,7 @@
    [[inputs.snmp.field]]
      name = "memAvailSwap"
      oid = "UCD-SNMP-MIB::memAvailSwap.0"
-    #  System memTotalReal
+   #  System memTotalReal
    [[inputs.snmp.field]]
      name = "memTotalReal"
      oid = "UCD-SNMP-MIB::memTotalReal.0"
@@ -93,61 +93,61 @@
    [[inputs.snmp.field]]
      name = "memAvailReal"
      oid = "UCD-SNMP-MIB::memAvailReal.0"
-	#  System memTotalFree
+   #  System memTotalFree
    [[inputs.snmp.field]]
      name = "memTotalFree"
      oid = "UCD-SNMP-MIB::memTotalFree.0"
-	#  System Status
+   #  System Status
    [[inputs.snmp.field]]
      name = "systemStatus"
      oid = "SYNOLOGY-SYSTEM-MIB::systemStatus.0"
-	 #  System temperature
+   #  System temperature
    [[inputs.snmp.field]]
      name = "temperature"
      oid = "SYNOLOGY-SYSTEM-MIB::temperature.0"
-	 #  System powerStatus
+   #  System powerStatus
    [[inputs.snmp.field]]
      name = "powerStatus"
      oid = "SYNOLOGY-SYSTEM-MIB::powerStatus.0"
-	 #  System systemFanStatus
+   #  System systemFanStatus
    [[inputs.snmp.field]]
      name = "systemFanStatus"
      oid = "SYNOLOGY-SYSTEM-MIB::systemFanStatus.0"
-	#  System cpuFanStatus
+   #  System cpuFanStatus
    [[inputs.snmp.field]]
      name = "cpuFanStatus"
      oid = "SYNOLOGY-SYSTEM-MIB::cpuFanStatus.0"
-	#  System modelName
+   #  System modelName
    [[inputs.snmp.field]]
      name = "modelName"
      oid = "SYNOLOGY-SYSTEM-MIB::modelName.0"
-	#  System serialNumber
+   #  System serialNumber
    [[inputs.snmp.field]]
      name = "serialNumber"
      oid = "SYNOLOGY-SYSTEM-MIB::serialNumber.0"
-	#  System version
+   #  System version
    [[inputs.snmp.field]]
      name = "version"
      oid = "SYNOLOGY-SYSTEM-MIB::version.0"
-	#  System upgradeAvailable
+   #  System upgradeAvailable
    [[inputs.snmp.field]]
      name = "upgradeAvailable"
      oid = "SYNOLOGY-SYSTEM-MIB::upgradeAvailable.0"
-    # System volume   
+   # System volume   
    [[inputs.snmp.table]]
      oid = "HOST-RESOURCES-MIB::hrStorageTable"
-     [[inputs.snmp.table.field]]
+   [[inputs.snmp.table.field]]
        is_tag = true
      oid = "HOST-RESOURCES-MIB::hrStorageDescr"
-    # System ssCpuUser 
+   # System ssCpuUser 
    [[inputs.snmp.field]]
-     name = "ssCpuUser "
+     name = "ssCpuUser"
      oid = ".1.3.6.1.4.1.2021.11.9.0"
-    # System ssCpuSystem  
+   # System ssCpuSystem  
    [[inputs.snmp.field]]
-     name = "ssCpuSystem  "
+     name = "ssCpuSystem"
      oid = ".1.3.6.1.4.1.2021.11.10.0"
-    # System ssCpuIdle   
+   # System ssCpuIdle   
    [[inputs.snmp.field]]
-     name = "ssCpuIdle   "
+     name = "ssCpuIdle"
      oid = ".1.3.6.1.4.1.2021.11.11.0"

--- a/input_syno_telegraf.conf
+++ b/input_syno_telegraf.conf
@@ -196,3 +196,19 @@
      name = "usersOTHER"
      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
      oid_index_suffix = "9"
+   # UPS Status
+   [[inputs.snmp.table.field]]
+     name = "upsStatus"
+     oid = "SYNOLOGY-UPS-MIB::upsInfoStatus"
+   # UPS Load
+   [[inputs.snmp.table.field]]
+     name = "upsLoad"
+     oid = "SYNOLOGY-UPS-MIB::upsInfoLoadValue"
+   # UPS Battery Charge
+   [[inputs.snmp.table.field]]
+     name = "upsCharge"
+     oid = "SYNOLOGY-UPS-MIB::upsBatteryChargeValue"
+   # UPS Battery Charge Warning
+   [[inputs.snmp.table.field]]
+     name = "upsWarning"
+     oid = "SYNOLOGY-UPS-MIB::upsBatteryChargeWarning"

--- a/input_syno_telegraf.conf
+++ b/input_syno_telegraf.conf
@@ -151,3 +151,48 @@
    [[inputs.snmp.field]]
      name = "ssCpuIdle"
      oid = ".1.3.6.1.4.1.2021.11.11.0"
+   # Service users CIFS
+   [[inputs.snmp.table.field]]
+     name = "usersCIFS"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "1"
+   # Service users AFP
+   [[inputs.snmp.table.field]]
+     name = "usersAFP"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "2"
+   # Service users NFS
+   [[inputs.snmp.table.field]]
+     name = "usersNFS"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "3"
+   # Service users FTP
+   [[inputs.snmp.table.field]]
+     name = "usersFTP"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "4"
+   # Service users SFTP
+   [[inputs.snmp.table.field]]
+     name = "usersSFTP"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "5"
+   # Service users HTTP
+   [[inputs.snmp.table.field]]
+     name = "usersHTTP"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "6"
+   # Service users TELNET
+   [[inputs.snmp.table.field]]
+     name = "usersTELNET"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "7"
+   # Service users SSH
+   [[inputs.snmp.table.field]]
+     name = "usersSSH"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "8"
+   # Service users OTHER
+   [[inputs.snmp.table.field]]
+     name = "usersOTHER"
+     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+     oid_index_suffix = "9"


### PR DESCRIPTION
Added the HTTP, CIFS, AFP, NFS, FTP, SFTP, TELNET, and SSH service user counts from SYNOLOGY-SERVICES-MIB