### PR TITLE
Consistent measurement naming

### DIFF
--- a/input_syno_telegraf.conf
+++ b/input_syno_telegraf.conf
@@ -8,207 +8,264 @@
 ##
 ## Synology 
 ##
- [[inputs.snmp]]
-   # List of agents to poll
-   agents = [  "xxx.xxx.xxx.xxx", "xxx.xxx.xxx.xxx" ]
-   # Polling interval
-   interval = "60s"
-   # Timeout for each SNMP query.
-   timeout = "10s"
-   # Number of retries to attempt within timeout.
-   retries = 3
-   # SNMP version, UAP only supports v1
-   version = 2
-   # SNMP community string.
-   community = "public"
-   # The GETBULK max-repetitions parameter
-   max_repetitions = 30
-   # Measurement name
-   name = "snmp.SYNO"
-   ##
-   ## System Details
-   ##
-   #  System name (hostname)
-   [[inputs.snmp.field]]
-     is_tag = true
-     name = "sysName"
-     oid = "RFC1213-MIB::sysName.0"
-   #  System vendor OID
-   [[inputs.snmp.field]]
-     name = "sysObjectID"
-     oid = "RFC1213-MIB::sysObjectID.0"
-   #  System description
-   [[inputs.snmp.field]]
-     name = "sysDescr"
-     oid = "RFC1213-MIB::sysDescr.0"
-   #  System contact
-   [[inputs.snmp.field]]
-     name = "sysContact"
-     oid = "RFC1213-MIB::sysContact.0"
-   #  System location
-   [[inputs.snmp.field]]
-     name = "sysLocation"
-     oid = "RFC1213-MIB::sysLocation.0"
-   #  System uptime
-   [[inputs.snmp.field]]
-     name = "sysUpTime"
-     oid = "RFC1213-MIB::sysUpTime.0"
-   # Inet interface
-   [[inputs.snmp.table]]
-     oid = "IF-MIB::ifTable"
-     [[inputs.snmp.table.field]]
-       is_tag = true
-     oid = "IF-MIB::ifDescr"
-   #Syno disk
-   [[inputs.snmp.table]]
-     oid = "SYNOLOGY-DISK-MIB::diskTable"
-     [[inputs.snmp.table.field]]
-       is_tag = true
-     oid = "SYNOLOGY-DISK-MIB::diskID" 
-   #Syno raid
-   [[inputs.snmp.table]]
-     oid = "SYNOLOGY-RAID-MIB::raidTable"
-     [[inputs.snmp.table.field]]
-       is_tag = true
-     oid = "SYNOLOGY-RAID-MIB::raidName" 
-   #Syno load
-   [[inputs.snmp.table]]
-     oid = "UCD-SNMP-MIB::laTable"
-     [[inputs.snmp.table.field]]
-       is_tag = true
-     oid = "UCD-SNMP-MIB::laNames"
-   #  System memTotalSwap
-   [[inputs.snmp.field]]
-     name = "memTotalSwap"
-     oid = "UCD-SNMP-MIB::memTotalSwap.0"
-   #  System memAvailSwap
-   [[inputs.snmp.field]]
-     name = "memAvailSwap"
-     oid = "UCD-SNMP-MIB::memAvailSwap.0"
-   #  System memTotalReal
-   [[inputs.snmp.field]]
-     name = "memTotalReal"
-     oid = "UCD-SNMP-MIB::memTotalReal.0"
-   #  System memAvailReal
-   [[inputs.snmp.field]]
-     name = "memAvailReal"
-     oid = "UCD-SNMP-MIB::memAvailReal.0"
-   #  System memTotalFree
-   [[inputs.snmp.field]]
-     name = "memTotalFree"
-     oid = "UCD-SNMP-MIB::memTotalFree.0"
-   #  System Status
-   [[inputs.snmp.field]]
-     name = "systemStatus"
-     oid = "SYNOLOGY-SYSTEM-MIB::systemStatus.0"
-   #  System temperature
-   [[inputs.snmp.field]]
-     name = "temperature"
-     oid = "SYNOLOGY-SYSTEM-MIB::temperature.0"
-   #  System powerStatus
-   [[inputs.snmp.field]]
-     name = "powerStatus"
-     oid = "SYNOLOGY-SYSTEM-MIB::powerStatus.0"
-   #  System systemFanStatus
-   [[inputs.snmp.field]]
-     name = "systemFanStatus"
-     oid = "SYNOLOGY-SYSTEM-MIB::systemFanStatus.0"
-   #  System cpuFanStatus
-   [[inputs.snmp.field]]
-     name = "cpuFanStatus"
-     oid = "SYNOLOGY-SYSTEM-MIB::cpuFanStatus.0"
-   #  System modelName
-   [[inputs.snmp.field]]
-     name = "modelName"
-     oid = "SYNOLOGY-SYSTEM-MIB::modelName.0"
-   #  System serialNumber
-   [[inputs.snmp.field]]
-     name = "serialNumber"
-     oid = "SYNOLOGY-SYSTEM-MIB::serialNumber.0"
-   #  System version
-   [[inputs.snmp.field]]
-     name = "version"
-     oid = "SYNOLOGY-SYSTEM-MIB::version.0"
-   #  System upgradeAvailable
-   [[inputs.snmp.field]]
-     name = "upgradeAvailable"
-     oid = "SYNOLOGY-SYSTEM-MIB::upgradeAvailable.0"
-   # System volume   
-   [[inputs.snmp.table]]
-     oid = "HOST-RESOURCES-MIB::hrStorageTable"
-   [[inputs.snmp.table.field]]
-       is_tag = true
-     oid = "HOST-RESOURCES-MIB::hrStorageDescr"
-   # System ssCpuUser 
-   [[inputs.snmp.field]]
-     name = "ssCpuUser"
-     oid = ".1.3.6.1.4.1.2021.11.9.0"
-   # System ssCpuSystem  
-   [[inputs.snmp.field]]
-     name = "ssCpuSystem"
-     oid = ".1.3.6.1.4.1.2021.11.10.0"
-   # System ssCpuIdle   
-   [[inputs.snmp.field]]
-     name = "ssCpuIdle"
-     oid = ".1.3.6.1.4.1.2021.11.11.0"
-   # Service users CIFS
-   [[inputs.snmp.table.field]]
-     name = "usersCIFS"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "1"
-   # Service users AFP
-   [[inputs.snmp.table.field]]
-     name = "usersAFP"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "2"
-   # Service users NFS
-   [[inputs.snmp.table.field]]
-     name = "usersNFS"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "3"
-   # Service users FTP
-   [[inputs.snmp.table.field]]
-     name = "usersFTP"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "4"
-   # Service users SFTP
-   [[inputs.snmp.table.field]]
-     name = "usersSFTP"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "5"
-   # Service users HTTP
-   [[inputs.snmp.table.field]]
-     name = "usersHTTP"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "6"
-   # Service users TELNET
-   [[inputs.snmp.table.field]]
-     name = "usersTELNET"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "7"
-   # Service users SSH
-   [[inputs.snmp.table.field]]
-     name = "usersSSH"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "8"
-   # Service users OTHER
-   [[inputs.snmp.table.field]]
-     name = "usersOTHER"
-     oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
-     oid_index_suffix = "9"
-   # UPS Status
-   [[inputs.snmp.table.field]]
-     name = "upsStatus"
-     oid = "SYNOLOGY-UPS-MIB::upsInfoStatus"
-   # UPS Load
-   [[inputs.snmp.table.field]]
-     name = "upsLoad"
-     oid = "SYNOLOGY-UPS-MIB::upsInfoLoadValue"
-   # UPS Battery Charge
-   [[inputs.snmp.table.field]]
-     name = "upsCharge"
-     oid = "SYNOLOGY-UPS-MIB::upsBatteryChargeValue"
-   # UPS Battery Charge Warning
-   [[inputs.snmp.table.field]]
-     name = "upsWarning"
-     oid = "SYNOLOGY-UPS-MIB::upsBatteryChargeWarning"
+[[inputs.snmp]]
+  # List of agents to poll
+  agents = [  "xxx.xxx.xxx.xxx", "xxx.xxx.xxx.xxx" ]
+  # Polling interval
+  interval = "60s"
+  # Timeout for each SNMP query.
+  timeout = "10s"
+  # Number of retries to attempt within timeout.
+  retries = 3
+  # SNMP version, UAP only supports v1
+  version = 2
+  # SNMP community string.
+  community = "public"
+  # The GETBULK max-repetitions parameter
+  max_repetitions = 30
+  ##
+  ## System Details
+  ##
+  name = "syno_system"
+  #  System name (hostname)
+  [[inputs.snmp.field]]
+    is_tag = true
+    name = "sysName"
+    oid = "RFC1213-MIB::sysName.0"
+  #  System vendor OID
+  [[inputs.snmp.field]]
+    name = "sysObjectID"
+    oid = "RFC1213-MIB::sysObjectID.0"
+  #  System description
+  [[inputs.snmp.field]]
+    name = "sysDescr"
+    oid = "RFC1213-MIB::sysDescr.0"
+  #  System contact
+  [[inputs.snmp.field]]
+    name = "sysContact"
+    oid = "RFC1213-MIB::sysContact.0"
+  #  System location
+  [[inputs.snmp.field]]
+    name = "sysLocation"
+    oid = "RFC1213-MIB::sysLocation.0"
+  #  System uptime
+  [[inputs.snmp.field]]
+    name = "sysUpTime"
+    oid = "RFC1213-MIB::sysUpTime.0"
+  #  System memTotalSwap
+  [[inputs.snmp.field]]
+    name = "memTotalSwap"
+    oid = "UCD-SNMP-MIB::memTotalSwap.0"
+  #  System memAvailSwap
+  [[inputs.snmp.field]]
+    name = "memAvailSwap"
+    oid = "UCD-SNMP-MIB::memAvailSwap.0"
+  #  System memTotalReal
+  [[inputs.snmp.field]]
+    name = "memTotalReal"
+    oid = "UCD-SNMP-MIB::memTotalReal.0"
+  #  System memAvailReal
+  [[inputs.snmp.field]]
+    name = "memAvailReal"
+    oid = "UCD-SNMP-MIB::memAvailReal.0"
+  #  System memTotalFree
+  [[inputs.snmp.field]]
+    name = "memTotalFree"
+    oid = "UCD-SNMP-MIB::memTotalFree.0"
+  #  System Status
+  [[inputs.snmp.field]]
+    name = "systemStatus"
+    oid = "SYNOLOGY-SYSTEM-MIB::systemStatus.0"
+  #  System temperature
+  [[inputs.snmp.field]]
+    name = "temperature"
+    oid = "SYNOLOGY-SYSTEM-MIB::temperature.0"
+  #  System powerStatus
+  [[inputs.snmp.field]]
+    name = "powerStatus"
+    oid = "SYNOLOGY-SYSTEM-MIB::powerStatus.0"
+  #  System systemFanStatus
+  [[inputs.snmp.field]]
+    name = "systemFanStatus"
+    oid = "SYNOLOGY-SYSTEM-MIB::systemFanStatus.0"
+  #  System cpuFanStatus
+  [[inputs.snmp.field]]
+    name = "cpuFanStatus"
+    oid = "SYNOLOGY-SYSTEM-MIB::cpuFanStatus.0"
+  #  System modelName
+  [[inputs.snmp.field]]
+    name = "modelName"
+    oid = "SYNOLOGY-SYSTEM-MIB::modelName.0"
+  #  System serialNumber
+  [[inputs.snmp.field]]
+    name = "serialNumber"
+    oid = "SYNOLOGY-SYSTEM-MIB::serialNumber.0"
+  #  System version
+  [[inputs.snmp.field]]
+    name = "version"
+    oid = "SYNOLOGY-SYSTEM-MIB::version.0"
+  #  System upgradeAvailable
+  [[inputs.snmp.field]]
+    name = "upgradeAvailable"
+    oid = "SYNOLOGY-SYSTEM-MIB::upgradeAvailable.0"
+  # System ssCpuUser 
+  [[inputs.snmp.field]]
+    name = "ssCpuUser"
+    oid = ".1.3.6.1.4.1.2021.11.9.0"
+  # System ssCpuSystem  
+  [[inputs.snmp.field]]
+    name = "ssCpuSystem"
+    oid = ".1.3.6.1.4.1.2021.11.10.0"
+  # System ssCpuIdle   
+  [[inputs.snmp.field]]
+    name = "ssCpuIdle"
+    oid = ".1.3.6.1.4.1.2021.11.11.0"
+
+  # Inet interface
+  [[inputs.snmp.table]]
+    name = "syno_if"
+    inherit_tags = [ "sysName" ]
+    oid = "IF-MIB::ifXTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "IF-MIB::ifName"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "IF-MIB::ifAlias"
+
+  #Syno disk
+  [[inputs.snmp.table]]
+    name = "syno_disk"
+    inherit_tags = [ "sysName" ]
+    oid = "SYNOLOGY-DISK-MIB::diskTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "SYNOLOGY-DISK-MIB::diskID" 
+
+  #Syno raid
+  [[inputs.snmp.table]]
+    name = "syno_raid"
+    inherit_tags = [ "sysName" ]
+    oid = "SYNOLOGY-RAID-MIB::raidTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "SYNOLOGY-RAID-MIB::raidName" 
+
+  #Syno load
+  [[inputs.snmp.table]]
+    name = "syno_load"
+    inherit_tags = [ "sysName" ]
+    oid = "UCD-SNMP-MIB::laTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "UCD-SNMP-MIB::laNames"
+
+  # System volume   
+  [[inputs.snmp.table]]
+    name = "syno_volume"
+    inherit_tags = [ "sysName" ]
+    oid = "HOST-RESOURCES-MIB::hrStorageTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "HOST-RESOURCES-MIB::hrStorageDescr"
+
+  # Services   
+  [[inputs.snmp.table]]
+    name = "syno_services"
+    inherit_tags = [ "sysName" ]
+    # Service users CIFS
+    [[inputs.snmp.table.field]]
+      name = "usersCIFS"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "1"
+    # Service users AFP
+    [[inputs.snmp.table.field]]
+      name = "usersAFP"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "2"
+    # Service users NFS
+    [[inputs.snmp.table.field]]
+      name = "usersNFS"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "3"
+    # Service users FTP
+    [[inputs.snmp.table.field]]
+      name = "usersFTP"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "4"
+    # Service users SFTP
+    [[inputs.snmp.table.field]]
+      name = "usersSFTP"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "5"
+    # Service users HTTP
+    [[inputs.snmp.table.field]]
+      name = "usersHTTP"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "6"
+    # Service users TELNET
+    [[inputs.snmp.table.field]]
+      name = "usersTELNET"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "7"
+    # Service users SSH
+    [[inputs.snmp.table.field]]
+      name = "usersSSH"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "8"
+    # Service users OTHER
+    [[inputs.snmp.table.field]]
+      name = "usersOTHER"
+      oid = "SYNOLOGY-SERVICES-MIB::serviceUsers"
+      oid_index_suffix = "9" 
+
+  # UPS Status
+  [[inputs.snmp.table]]
+    name = "syno_ups"
+    inherit_tags = [ "sysName" ]
+    # _UPS status
+    [[inputs.snmp.table.field]]
+      name = "upsStatus"
+      oid = "SYNOLOGY-UPS-MIB::upsInfoStatus"
+    # UPS Load
+    [[inputs.snmp.table.field]]
+      name = "upsLoad"
+      oid = "SYNOLOGY-UPS-MIB::upsInfoLoadValue"
+    # UPS Battery Charge
+    [[inputs.snmp.table.field]]
+      name = "upsCharge"
+      oid = "SYNOLOGY-UPS-MIB::upsBatteryChargeValue"
+    # UPS Battery Charge Warning
+    [[inputs.snmp.table.field]]
+      name = "upsWarning"
+      oid = "SYNOLOGY-UPS-MIB::upsBatteryChargeWarning"
+
+  # Space I/O   
+  [[inputs.snmp.table]]
+    name = "syno_spaceio"
+    inherit_tags = [ "sysName" ]
+    oid = "SYNOLOGY-SPACEIO-MIB::spaceIOTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "SYNOLOGY-SPACEIO-MIB::spaceIODevice"
+
+  # Storage I/O   
+  [[inputs.snmp.table]]
+    name = "syno_storageio"
+    inherit_tags = [ "sysName" ]
+    oid = "SYNOLOGY-STORAGEIO-MIB::storageIOTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "SYNOLOGY-STORAGEIO-MIB::storageIODevice"
+
+  # Flash Cache  
+  [[inputs.snmp.table]]
+    name = "syno_flashcache"
+    inherit_tags = [ "sysName" ]
+    oid = "SYNOLOGY-FLASHCACHE-MIB::flashCacheTable"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "SYNOLOGY-FLASHCACHE-MIB::flashCacheSSDPath"
+    [[inputs.snmp.table.field]]
+      is_tag = true
+      oid = "SYNOLOGY-FLASHCACHE-MIB::flashCacheSpacePath"


### PR DESCRIPTION
- Do not use "." in measurement names. InfluxDB requires extra handling for dots in names.
- Consistent naming for all measurements. All measurement names start now with "syno_".
- Changed interface stats to ifXTable. Synology recommends using the ifHC.. counters.
- Added Storage I/O and Space I/O and Flash Cache stats
- UPS stats have now their own measurement. Before they ended up in the same measurement as volumes.